### PR TITLE
feature(mods): Mod Manager UI, Rescan and Hot Reload reflect deleted mods

### DIFF
--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -1425,10 +1425,8 @@ static void DoHotReload() {
 }
 
 void PortMenu::AddMenuMods() {
-    AddMenuEntry("Mods", CVAR_SETTING("Menu.ModsSidebarSection"));
-
-    WidgetPath path = { "Mods", "Mods", SECTION_COLUMN_1 };
-    AddSidebarEntry("Mods", "Mods", 1);
+    WidgetPath path = { "Assets", "Script Mods", SECTION_COLUMN_1 };
+    AddSidebarEntry("Assets", "Script Mods", 1);
     AddWidget(path, "mods_panel", WIDGET_CUSTOM)
         .CustomFunction([](WidgetInfo&) {
             // --- Action bar -------------------------------------------------

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -21,6 +21,7 @@
 #ifndef DISABLE_SCRIPTING
 #include <ship/scripting/ScriptLoader.h>
 #include "../mods/HookManager.h"
+#include "../mods/ModRegistry.h"
 
 namespace ssb64 { void MountModsDir(); }
 #endif
@@ -33,6 +34,7 @@ namespace ssb64 { void MountModsDir(); }
 
 #include <algorithm>
 #include <cassert>
+#include <cctype>
 #include <cstring>
 #include <filesystem>
 
@@ -1367,6 +1369,17 @@ void PortMenu::AddMenuAssets() {
 }
 
 #ifndef DISABLE_SCRIPTING
+// Cached, read-only mod list for the Mods panel. The set of installed mods
+// only changes on a reload or restart, so we snapshot on demand (first view,
+// Rescan, and after a Hot Reload) rather than re-scanning every frame.
+static std::vector<ssb64::mods::ModInfo> s_modList;
+static bool s_modListLoaded = false;
+
+static void RefreshModList() {
+    s_modList = ssb64::mods::ModRegistry::Snapshot();
+    s_modListLoaded = true;
+}
+
 static void DoHotReload() {
     auto scripting = Ship::Context::GetInstance()->GetScriptLoader();
     if (!scripting) {
@@ -1396,6 +1409,7 @@ static void DoHotReload() {
             /*postInit=*/[](const std::string&) {
                 ssb64::mods::HookManager::ClearCurrentOwner();
             });
+        RefreshModList();
     } catch (const std::exception& e) {
         SPDLOG_ERROR("Mod reload failed: {}", e.what());
     }
@@ -1408,16 +1422,127 @@ void PortMenu::AddMenuMods() {
     AddSidebarEntry("Mods", "Mods", 1);
     AddWidget(path, "mods_panel", WIDGET_CUSTOM)
         .CustomFunction([](WidgetInfo&) {
+            // --- Action bar -------------------------------------------------
             if (ImGui::Button("Hot Reload")) {
-                DoHotReload();
+                DoHotReload(); // re-snapshots s_modList when it finishes
             }
             if (ImGui::IsItemHovered()) {
                 ImGui::SetTooltip("Unload + recompile + re-init all TCC mods.\n"
                                   "Adding or removing mod folders still needs an engine restart.");
             }
+            ImGui::SameLine();
+            if (ImGui::Button("Rescan")) {
+                RefreshModList();
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Re-read the mods/ folder without reloading the mods.");
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Open Mods Folder")) {
+                std::string modsPath = Ship::Context::GetPathRelativeToAppDirectory("mods");
+                std::error_code ec;
+                fs::create_directories(modsPath, ec);
+                SDL_OpenURL(std::string("file:///" + fs::absolute(modsPath).string()).c_str());
+            }
+
+            // Build the list once on first view; thereafter only on demand.
+            if (!s_modListLoaded) {
+                RefreshModList();
+            }
+
+            // --- Filter -----------------------------------------------------
+            static char filter[64] = "";
+            ImGui::SetNextItemWidth(-1.0f);
+            ImGui::InputTextWithHint("##modfilter", "Filter by name or author", filter,
+                                     sizeof(filter));
+
             ImGui::Separator();
-            ImGui::TextWrapped("Mods are loaded from the mods/ folder next to the executable. "
-                               "Drop a folder or .o2r in there, then Hot Reload (or restart) to pick it up.");
+
+            if (s_modList.empty()) {
+                ImGui::TextWrapped("No mods found. Drop a mod folder or .o2r into the mods/ "
+                                   "folder next to the executable, then press Rescan (or "
+                                   "restart).");
+                return;
+            }
+
+            auto toLower = [](std::string s) {
+                std::transform(s.begin(), s.end(), s.begin(),
+                               [](unsigned char c) { return (char)std::tolower(c); });
+                return s;
+            };
+            const std::string needle = toLower(filter);
+            auto matches = [&](const ssb64::mods::ModInfo& mod) {
+                return needle.empty() ||
+                       toLower(mod.name).find(needle) != std::string::npos ||
+                       toLower(mod.author).find(needle) != std::string::npos;
+            };
+
+            // --- Mod cards --------------------------------------------------
+            int loadedCount = 0;
+            int issueCount = 0;
+            int shown = 0;
+            for (const auto& mod : s_modList) {
+                using ssb64::mods::ModState;
+                if (mod.state == ModState::Loaded) {
+                    loadedCount++;
+                }
+                if (mod.state == ModState::InvalidManifest) {
+                    issueCount++;
+                }
+                if (!matches(mod)) {
+                    continue;
+                }
+                shown++;
+
+                ImGui::PushID(mod.archivePath.c_str()); // unique id per card
+
+                switch (mod.state) {
+                    case ModState::Loaded:
+                        ImGui::TextColored(ImVec4(0.35f, 0.85f, 0.40f, 1.0f), "LOADED");
+                        break;
+                    case ModState::NotLoaded:
+                        ImGui::TextColored(ImVec4(0.65f, 0.65f, 0.65f, 1.0f), "not loaded");
+                        break;
+                    case ModState::InvalidManifest:
+                        ImGui::TextColored(ImVec4(0.95f, 0.75f, 0.20f, 1.0f), "manifest issue");
+                        break;
+                }
+
+                ImGui::SameLine();
+                if (!mod.version.empty()) {
+                    ImGui::Text("%s  v%s", mod.name.c_str(), mod.version.c_str());
+                } else {
+                    ImGui::TextUnformatted(mod.name.c_str());
+                }
+                if (ImGui::IsItemHovered() && !mod.archivePath.empty()) {
+                    ImGui::SetTooltip("%s", mod.archivePath.c_str());
+                }
+
+                if (!mod.author.empty()) {
+                    ImGui::TextDisabled("by %s", mod.author.c_str());
+                }
+                if (!mod.description.empty()) {
+                    ImGui::TextWrapped("%s", mod.description.c_str());
+                }
+                if (!mod.note.empty()) {
+                    ImGui::TextColored(ImVec4(0.95f, 0.75f, 0.20f, 1.0f), "%s", mod.note.c_str());
+                }
+
+                ImGui::PopID();
+                ImGui::Separator();
+            }
+
+            if (shown == 0) {
+                ImGui::TextDisabled("No mods match the filter.");
+            }
+
+            ImGui::Spacing();
+            std::string footer = std::to_string(static_cast<int>(s_modList.size())) +
+                                 " installed  |  " + std::to_string(loadedCount) + " loaded";
+            if (issueCount > 0) {
+                footer += "  |  " + std::to_string(issueCount) + " issue(s)";
+            }
+            ImGui::TextUnformatted(footer.c_str());
         });
 }
 #endif

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -23,7 +23,7 @@
 #include "../mods/HookManager.h"
 #include "../mods/ModRegistry.h"
 
-namespace ssb64 { void MountModsDir(); }
+namespace ssb64 { void MountModsDir(); void UnmountMissingMods(); }
 #endif
 
 #include <imgui.h>
@@ -1376,6 +1376,12 @@ static std::vector<ssb64::mods::ModInfo> s_modList;
 static bool s_modListLoaded = false;
 
 static void RefreshModList() {
+    // Sync the mounted set to what's actually on disk so the list reflects mods
+    // added or deleted at runtime: drop archives whose folder is gone, pick up
+    // newly dropped ones. New mods appear as "not loaded" until a Hot Reload
+    // compiles them; this only refreshes the inventory, it does not recompile.
+    ssb64::UnmountMissingMods();
+    ssb64::MountModsDir();
     s_modList = ssb64::mods::ModRegistry::Snapshot();
     s_modListLoaded = true;
 }
@@ -1397,9 +1403,12 @@ static void DoHotReload() {
             /*postExit=*/[](const std::string& mod) {
                 ssb64::mods::HookManager::UninstallHooksForOwner(mod.c_str());
             });
-        /* Pick up any new mod folders/archives that landed in mods/
-         * since the last load. Idempotent: already-mounted archives
-         * are skipped. */
+        /* Now that every script is unloaded, drop archives whose mod folder
+         * was deleted at runtime — otherwise it stays mounted and gets
+         * recompiled below as if it were still installed. Then pick up any
+         * new folders/archives that landed in mods/ since the last load
+         * (idempotent: already-mounted archives are skipped). */
+        ssb64::UnmountMissingMods();
         ssb64::MountModsDir();
         scripting->CompileAll();
         scripting->LoadAll(

--- a/port/mods/ModRegistry.cpp
+++ b/port/mods/ModRegistry.cpp
@@ -1,0 +1,123 @@
+/*
+ * ModRegistry.cpp — see ModRegistry.h.
+ *
+ * Walks the archives the engine already mounted (ArchiveManager) rather
+ * than re-scanning the filesystem: that way a "mod" is whatever the engine
+ * actually has, manifest parsing is reused from the Archive layer
+ * (GetManifest), and per-archive reads avoid the VFS path collision you'd
+ * hit reading "manifest.json" globally when several mods each ship one.
+ */
+#include "ModRegistry.h"
+
+#include <libultraship/libultraship.h> // Ship::Context
+#include <ship/resource/ResourceManager.h>
+#include <ship/resource/archive/ArchiveManager.h>
+#include <ship/resource/archive/Archive.h> // Archive, ArchiveManifest, GetManifest
+#include <ship/scripting/ScriptLoader.h>   // GetLoadersInDependencyOrder
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <unordered_set>
+#include <utility>
+
+namespace ssb64::mods {
+namespace {
+
+bool CaseInsensitiveLess(const std::string& a, const std::string& b) {
+    return std::lexicographical_compare(
+        a.begin(), a.end(), b.begin(), b.end(),
+        [](unsigned char x, unsigned char y) { return std::tolower(x) < std::tolower(y); });
+}
+
+/* Folder name, or archive filename without extension — a readable fallback
+ * label when a mod's manifest carries no usable "name". */
+std::string PathLabel(const std::string& archivePath) {
+    const std::filesystem::path p(archivePath);
+    std::string stem = p.stem().string();
+    if (!stem.empty()) {
+        return stem;
+    }
+    std::string fname = p.filename().string();
+    return fname.empty() ? archivePath : fname;
+}
+
+} // namespace
+
+std::vector<ModInfo> ModRegistry::Snapshot() {
+    std::vector<ModInfo> mods;
+
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx) {
+        return mods;
+    }
+    auto resourceManager = ctx->GetResourceManager();
+    if (!resourceManager) {
+        return mods;
+    }
+    auto archiveManager = resourceManager->GetArchiveManager();
+    if (!archiveManager) {
+        return mods;
+    }
+    auto archives = archiveManager->GetArchives();
+    if (!archives) {
+        return mods;
+    }
+
+    /* Names of mods that compiled and ran ModInit successfully. Keyed by
+     * manifest name — the same key ScriptLoader uses internally. If the
+     * loader is not up, every mod simply reports NotLoaded. */
+    std::unordered_set<std::string> loaded;
+    if (auto scripting = ctx->GetScriptLoader()) {
+        for (const auto& name : scripting->GetLoadersInDependencyOrder()) {
+            loaded.insert(name);
+        }
+    }
+
+    for (const auto& archive : *archives) {
+        if (!archive) {
+            continue;
+        }
+        /* A mounted archive is a managed mod iff it carries a manifest.json.
+         * Excludes the base game + shader archives, which carry none. */
+        if (!archive->HasFile("manifest.json")) {
+            continue;
+        }
+
+        const Ship::ArchiveManifest& manifest = archive->GetManifest();
+
+        ModInfo info;
+        info.archivePath = archive->GetPath();
+        info.version = manifest.Version;
+        info.author = manifest.Author;
+        info.description = manifest.Description;
+
+        if (manifest.Name.empty()) {
+            /* manifest.json exists but parsed to no name: malformed JSON or
+             * a missing "name". Surface it instead of hiding it. */
+            info.name = PathLabel(info.archivePath);
+            info.state = ModState::InvalidManifest;
+            info.note = "manifest.json is missing a \"name\" or could not be parsed";
+        } else {
+            info.name = manifest.Name;
+            info.state = loaded.count(manifest.Name) ? ModState::Loaded : ModState::NotLoaded;
+        }
+
+        mods.push_back(std::move(info));
+    }
+
+    /* Loaded mods first, then case-insensitive by name — stable across
+     * frames so the rendered list does not jump around. */
+    std::sort(mods.begin(), mods.end(), [](const ModInfo& a, const ModInfo& b) {
+        const int rankA = (a.state == ModState::Loaded) ? 0 : 1;
+        const int rankB = (b.state == ModState::Loaded) ? 0 : 1;
+        if (rankA != rankB) {
+            return rankA < rankB;
+        }
+        return CaseInsensitiveLess(a.name, b.name);
+    });
+
+    return mods;
+}
+
+} // namespace ssb64::mods

--- a/port/mods/ModRegistry.h
+++ b/port/mods/ModRegistry.h
@@ -1,0 +1,62 @@
+/*
+ * ModRegistry.h — read-only inventory of the engine's mounted mods.
+ *
+ * Phase 1 of the in-game Mod Manager (see docs/mod_manager_menu_plan.md).
+ * This is the *model* behind the Mods menu panel: a pure, side-effect-free
+ * query that enumerates the mods the engine currently has mounted, reads
+ * their manifest metadata, and marks which ones actually loaded.
+ *
+ * It deliberately knows nothing about ImGui — the menu renders a snapshot.
+ * That keeps mod discovery testable and reusable independently of the UI.
+ *
+ * Source of truth: a mounted archive (folder or .o2r/.otr/.zip) is treated
+ * as a mod iff it carries a manifest.json at its root — exactly how
+ * MountModsDir (port.cpp) recognises a mod folder. The base game and shader
+ * archives carry no manifest.json and are therefore excluded automatically.
+ *
+ * "Loaded" is keyed by the manifest name, which is the same key
+ * ScriptLoader stores its loaded modules under (mLoadedScripts[Name]).
+ *
+ * Only compiled when scripting is enabled (the whole port/mods/ tree is
+ * filtered out under DISABLE_SCRIPTING by the top-level CMakeLists).
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace ssb64::mods {
+
+/* Lifecycle state of an installed mod, as the user should see it. */
+enum class ModState {
+    Loaded,          /* compiled + ModInit ran: live in the engine        */
+    NotLoaded,       /* mounted/installed but not currently loaded         */
+    InvalidManifest, /* mounted, but manifest.json is unnamed/unparseable  */
+};
+
+/* A single installed mod, flattened for display. Plain value type. */
+struct ModInfo {
+    std::string name;        /* manifest "name" (or a path-derived fallback) */
+    std::string version;     /* manifest "version"                           */
+    std::string author;      /* manifest "author"                            */
+    std::string description; /* manifest "description"                       */
+    std::string archivePath; /* absolute path of the mounted folder / .o2r   */
+    ModState state = ModState::NotLoaded;
+    std::string note; /* human-readable detail; set for InvalidManifest */
+};
+
+class ModRegistry {
+  public:
+    /*
+     * Snapshot the currently-mounted mods. Pure query: no side effects,
+     * never throws. Returns an empty vector if the resource/archive
+     * subsystems are not up yet (e.g. called too early in boot).
+     *
+     * Result is ordered deterministically: loaded mods first, then
+     * case-insensitively by name — so the list does not reshuffle between
+     * frames when the menu re-renders.
+     */
+    static std::vector<ModInfo> Snapshot();
+};
+
+} // namespace ssb64::mods

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -505,6 +505,40 @@ void MountModsDir() {
 	walk(modsDir);
 }
 
+/* Unmount mod archives whose on-disk source no longer exists. MountModsDir
+ * only ever ADDS archives, so a mod folder/.o2r deleted at runtime stays
+ * mounted in the ArchiveManager for the rest of the session — Hot Reload would
+ * recompile it from the still-mounted VFS and Rescan would still list it.
+ * Removing the stale archive here lets both reflect deletions. Only archives
+ * carrying a manifest.json are considered, so the base game + shader archives
+ * are never touched. Call with mod scripts already unloaded (the loaded image
+ * is independent of the archive, but unloading first keeps state consistent). */
+void UnmountMissingMods() {
+	namespace fs = std::filesystem;
+	auto rm = sContext ? sContext->GetResourceManager() : nullptr;
+	if (!rm) return;
+	auto am = rm->GetArchiveManager();
+	if (!am) return;
+	auto archives = am->GetArchives();
+	if (!archives) return;
+
+	/* Collect first, then remove — don't mutate the manager's list mid-walk. */
+	std::vector<std::string> stale;
+	for (const auto& a : *archives) {
+		if (!a) continue;
+		if (!a->HasFile("manifest.json")) continue; /* not a mod */
+		const std::string path = a->GetPath();
+		std::error_code ec;
+		if (!fs::exists(fs::path(path), ec)) {
+			stale.push_back(path);
+		}
+	}
+	for (const auto& path : stale) {
+		am->RemoveArchive(path);
+		port_log("SSB64: unmounted deleted mod archive -> %s\n", path.c_str());
+	}
+}
+
 } // namespace ssb64
 #endif
 

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -1083,6 +1083,20 @@ void PortShutdown(void) {
 	// that's about to be torn down).
 	ssb64::mods::HookManager::Shutdown();
 	ssb64::mods::SymbolResolver::Shutdown();
+
+	// Unload mod scripts now, while the Context's EventSystem is still fully
+	// alive, so each mod's ModExit (which calls UNREGISTER_LISTENER) can reach
+	// it. Otherwise the only UnloadAll happens inside ~Context via the
+	// sContext.reset() below — by which point the EventSystem is being torn
+	// down, so EventSystemUnregisterListener -> Context::GetEventSystem
+	// dereferences a dead shared_ptr<EventSystem> and crashes on exit whenever
+	// a listener-registering mod (e.g. one that REGISTER_LISTENERs in ModInit)
+	// is loaded. The later ~Context UnloadAll then finds nothing loaded.
+	if (sContext) {
+		if (auto scripting = sContext->GetScriptLoader()) {
+			scripting->UnloadAll();
+		}
+	}
 #endif
 
 	// Drop audio bridge resource references before Ship::Context goes away.


### PR DESCRIPTION
## What

Currently, Battleship does have a menu for Hi-Res Texture Packs and more, 
but not a proper Mod menu where people can see what Mods they have installed,
or even reload or scan for new mods. This fixes that.
One issue that I had during development of this mod menu was that 
the Mods menu's **Rescan** and **Hot Reload** buttons did not pick up a mod
folder deleted at runtime — the mod kept showing `LOADED` and Rescan still
listed it.

## Why

`MountModsDir` (`port/port.cpp`) only ever **adds** archives (skips
already-mounted, `AddArchive`s new). Nothing unmounts. So a deleted mod folder
stays mounted in the `ArchiveManager` for the session:

- **Hot Reload** unloads → re-mounts (no-op) → recompiles the still-mounted
  archive → `LOADED` again.
- **Rescan** re-reads the mounted archives → the deleted mod is still there.

## Fix

Add `UnmountMissingMods()` (`port/port.cpp`): for each mounted archive carrying a
`manifest.json` whose on-disk path no longer exists, call
`ArchiveManager::RemoveArchive`. The base game + shader archives (no manifest)
are never touched.

Wire it in (`port/gui/PortMenu.cpp`):

- **Hot Reload** (`DoHotReload`): after `UnloadAll`, before re-mount/recompile —
  so a deleted mod is dropped instead of recompiled.
- **Rescan** (`RefreshModList`): sync mounts to disk (drop gone, pick up new),
  then re-snapshot. New mods appear as *not loaded* until a Hot Reload compiles
  them; this only refreshes the inventory.

## Test plan

Load with a mod, delete its folder while running, press **Rescan** (then **Hot
Reload**). It should drop from the list. Drop a new folder in and Rescan — it
should appear (not loaded), then load on Hot Reload.

## Notes

- Compiles and boots clean (mods still load — no regression); the unmount path
  itself needs a button click to exercise, hence the manual test plan.
- Tested with the Player Tint mod I left in the previous Documentation PR I made, works flawlessly with Hot Reload (characters "un-tinted" in real time).
- Uses `ArchiveManager::RemoveArchive`, the unmount primitive flagged in the Mod
  Manager design note as the main Phase-2 dependency.
- One thing I did not test (because they aren't many mods for Battleship yet) is that what would happen with a mod with the size of Smash Remix? But that can be solved on the long run.
