### PR TITLE
feat(port): mute on window focus loss

### DIFF
--- a/port/focus.cpp
+++ b/port/focus.cpp
@@ -1,0 +1,30 @@
+#include "focus.h"
+
+#include "libultraship/bridge/consolevariablebridge.h"
+#include "hooks/Events.h"
+
+namespace ssb64 {
+
+static float sSavedMasterVolume = -1.0f;
+
+static void OnWindowFocus(IEvent* raw) {
+    auto* ev = reinterpret_cast<WindowFocusEvent*>(raw);
+
+    if (!ev->Focused) {
+        if (CVarGetInteger("gSettings.FocusControl.MuteOnFocusLoss", 0)) {
+            sSavedMasterVolume = CVarGetFloat("gSettings.Audio.MasterVolume", 1.0f);
+            CVarSetFloat("gSettings.Audio.MasterVolume", 0.0f);
+        }
+    } else {
+        if (sSavedMasterVolume >= 0.0f) {
+            CVarSetFloat("gSettings.Audio.MasterVolume", sSavedMasterVolume);
+            sSavedMasterVolume = -1.0f;
+        }
+    }
+}
+
+void RegisterFocusListener() {
+    REGISTER_LISTENER(WindowFocusEvent, EVENT_PRIORITY_NORMAL, OnWindowFocus);
+}
+
+} // namespace ssb64

--- a/port/focus.h
+++ b/port/focus.h
@@ -1,0 +1,4 @@
+#pragma once
+namespace ssb64 {
+void RegisterFocusListener();
+}

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -1246,6 +1246,14 @@ void PortMenu::AddMenuSettings() {
         .Max(1.0f)
         .IsPercentage());
 
+    AddWidget(path, "Focus Behavior", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Mute on Focus Loss", WIDGET_CVAR_CHECKBOX)
+        .CVar("gSettings.FocusControl.MuteOnFocusLoss")
+        .RaceDisable(false)
+        .Options(CheckboxOptions()
+            .Tooltip("Silences game audio while the window is unfocused. Restores volume on refocus.")
+            .DefaultValue(false));
+
     // --- Cheats ---
     path.sidebarName = "Cheats";
     path.column = SECTION_COLUMN_1;

--- a/port/hooks/Events.cpp
+++ b/port/hooks/Events.cpp
@@ -28,4 +28,6 @@ extern "C" void PortRegisterEvents(void) {
     REGISTER_EVENT(FighterHitboxSlotResetEvent);
     REGISTER_EVENT(FighterParentKindResolveEvent);
     REGISTER_EVENT(FighterRapidJabStatusQueryEvent);
+
+    REGISTER_EVENT(WindowFocusEvent);
 }

--- a/port/hooks/Events.h
+++ b/port/hooks/Events.h
@@ -12,3 +12,4 @@
 
 #include "list/EngineEvent.h"
 #include "list/FighterEvent.h"
+#include "ship/events/WindowEvents.h"

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -48,6 +48,7 @@
 #include "renderdoc_trigger.h"
 #include "port_log.h"
 #include "fighter_registry.h"
+#include "focus.h"
 
 #ifndef DISABLE_SCRIPTING
 #include <ship/scripting/ScriptLoader.h>
@@ -946,6 +947,7 @@ static int PortInitImpl(int argc, char* argv[]) {
 	// Must happen AFTER InitEventSystem (PortRegisterEvents calls
 	// EventSystemRegisterEvent, which dereferences Context::GetEventSystem()).
 	PortRegisterEvents();
+	ssb64::RegisterFocusListener();
 	port_log("SSB64: Engine events registered\n");
 
 #ifndef DISABLE_SCRIPTING


### PR DESCRIPTION
## What

One independent behavior, off-by-default-friendly and independently toggled from **Settings > Audio > Focus Behavior**:

| Setting | CVar | Default |
|---|---|---|
| Mute on Focus Loss | `gSettings.FocusControl.MuteOnFocusLoss` | Off |

**Mute**: when the window loses focus and the CVar is enabled, `gSettings.Audio.MasterVolume` is saved and set to `0.0f`. On refocus, the saved value is restored. Volume-save state uses a sentinel of `-1.0f` so a double focus-loss doesn't corrupt the saved value.

## Implementation

- `port/focus.h` / `port/focus.cpp` — `ssb64::RegisterFocusListener()` registers a `WindowFocusEvent` listener via `REGISTER_LISTENER`. No global listener object; the listener ID is fire-and-forget (unregistered on shutdown via the event system teardown).
- `port/hooks/Events.h` — adds `#include "ship/events/WindowEvents.h"` so `WindowFocusEvent` is available to all port TUs that include `Events.h`.
- `port/hooks/Events.cpp` — adds `REGISTER_EVENT(WindowFocusEvent)` to `PortRegisterEvents()`.
- `port/port.cpp` — calls `ssb64::RegisterFocusListener()` immediately after `PortRegisterEvents()`.
- `port/gui/PortMenu.cpp` — adds "Focus Behavior" separator and one checkbox in the Audio sidebar, after the voice volume slider.

`focus.cpp` is picked up by `file(GLOB_RECURSE SSB64_SRC_PORT "port/*.cpp" ...)` in `CMakeLists.txt`; no CMake edit was needed.

Depends on [PR#7](https://github.com/JRickey/libultraship/pull/7) of libultraship.

## Test plan

- [ ] Build succeeds on Windows (MSVC/Ninja) and Linux (CachyOS, Linux GCC 16.1.1) 
- [ ] "Mute on Focus Loss" checked: audio silences on alt-tab, restores on refocus
- [ ] "Mute on Focus Loss" unchecked: audio unaffected by alt-tab
- [ ] Rapid alt-tab (focus-lost/gained in quick succession): volume sentinel prevents double-save corruption
- [ ] Settings > Audio shows "Focus Behavior" section with checkbox and tooltip.