### PR TITLE
Add option to disable in-game HUD

### DIFF
--- a/port/enhancements/DisableHUD.cpp
+++ b/port/enhancements/DisableHUD.cpp
@@ -1,0 +1,21 @@
+#include "enhancements.h"
+
+#include <libultraship/bridge/consolevariablebridge.h>
+
+constexpr const char* kDisableHUDCVar = "gEnhancements.DisableHUD";
+
+extern "C" {
+    bool port_enhancement_is_hud_disabled(void) {
+        return CVarGetInteger(kDisableHUDCVar, 0) != 0;
+    }
+}
+
+namespace ssb64 {
+    namespace enhancements {
+
+        const char* DisableHUDCVarName() {
+            return kDisableHUDCVar;
+        }
+
+    } // namespace enhancements
+} // namespace ssb64

--- a/port/enhancements/enhancements.h
+++ b/port/enhancements/enhancements.h
@@ -105,6 +105,7 @@ const char* ClassicCoopCVarName();
 const char* ClassicCoopFriendlyFireCVarName();
 const char* ShuffleMusicCVarName();
 const char* MusicSelectionCVarName();
+const char* DisableHUDCVarName();
 
 // Discord Rich Presence
 void UpdateDiscordPresence(const char* gameState, const char* matchDetails);

--- a/port/gui/PortMenu.cpp
+++ b/port/gui/PortMenu.cpp
@@ -1115,6 +1115,13 @@ void PortMenu::AddMenuSettings() {
         .RaceDisable(false)
         .Options(CheckboxOptions().Tooltip("Allows the player to pick a custom BGM track after the stage selection screen (music shuffling is ignored if this is turned on)."));
 
+    // --- Other ---
+    AddWidget(path, "Other", WIDGET_SEPARATOR_TEXT);
+        AddWidget(path, "Disable HUD", WIDGET_CVAR_CHECKBOX)
+        .CVar(ssb64::enhancements::DisableHUDCVarName())
+        .RaceDisable(false)
+        .Options(CheckboxOptions().Tooltip("Disables the in-game HUD. Note that some icons will still be visible (e.g. CPU icons in 1P Mode on the top-left.)"));
+
     // --- Input customization ---
     path.sidebarName = "Input Mappings";
     path.column = SECTION_COLUMN_1;


### PR DESCRIPTION
Adds option to disable the in-game HUD. Stock icons, damage percent, etc. will be rendered invisibly. Useful for press kit or cinematic purposes. Note though that some elements will still appear, like the amount of targets left in Target Test, etc.

<img width="2560" height="1440" alt="screen_2026-06-23_12-24-04" src="https://github.com/user-attachments/assets/9dc95efd-80bf-4fe4-a56c-996b7ae343c5" />

Decomp PR: https://github.com/JRickey/ssb-decomp-re/pull/11