### PR TITLE
macOS: Retina-crisp menu fonts, press-and-hold fix, correct bundle version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -862,6 +862,13 @@ else()
     add_dependencies(${PROJECT_NAME} libultraship TorchExternal discord-rpc)
     target_link_libraries(${PROJECT_NAME} PRIVATE libultraship discord-rpc)
 endif()
+
+# macOS: the port calls CFPreferences* directly (ApplePressAndHoldEnabled fix
+# in main()), so link CoreFoundation explicitly rather than relying on it
+# arriving transitively through libultraship's PRIVATE framework links.
+if (APPLE)
+    target_link_libraries(${PROJECT_NAME} PRIVATE "-framework CoreFoundation")
+endif()
 add_dependencies(ssb64_game GenerateCreditsAssets)
 if (NOT DISABLE_SCRIPTING)
     # funchook hook backend (libultraship is already linked above).

--- a/port/gui/Menu.cpp
+++ b/port/gui/Menu.cpp
@@ -59,16 +59,34 @@ std::string FindMenuAssetPath(const std::string& relativePath) {
 }
 
 ImFont* AddMergedMenuFont(ImGuiIO& io, float size, const std::string& path = std::string()) {
+    // HiDPI/Retina: bake the glyph atlas at device density so the menu text is
+    // crisp instead of a bilinearly-upscaled 1x atlas. On a Retina display the
+    // ImGui SDL2 backend sets DisplayFramebufferScale=2, which otherwise
+    // stretches the 1x-baked glyphs and makes the menu look soft. Raising
+    // RasterizerDensity increases only the rasterization resolution, not the
+    // layout metrics, so on-screen sizes are unchanged. A fixed 2x is used on
+    // macOS (the common backing scale): perfect 1:1 on a 2x display, and on a
+    // 1x display the 2x atlas simply downsamples — still crisp, just a little
+    // extra atlas memory. (A window DPI accessor in libultraship would let this
+    // be derived dynamically; kept port-local here to avoid a submodule change.)
+#ifdef __APPLE__
+    constexpr float kMenuFontDensity = 2.0f;
+#else
+    constexpr float kMenuFontDensity = 1.0f;
+#endif
+
     ImFont* font = nullptr;
     if (path.empty()) {
         ImFontConfig fontCfg;
         fontCfg.OversampleH = fontCfg.OversampleV = 1;
         fontCfg.PixelSnapH = true;
         fontCfg.SizePixels = size;
+        fontCfg.RasterizerDensity = kMenuFontDensity;
         font = io.Fonts->AddFontDefault(&fontCfg);
     } else {
         ImFontConfig fontCfg;
         fontCfg.FontDataOwnedByAtlas = false;
+        fontCfg.RasterizerDensity = kMenuFontDensity;
         font = io.Fonts->AddFontFromFileTTF(path.c_str(), size, &fontCfg);
     }
 
@@ -78,6 +96,7 @@ ImFont* AddMergedMenuFont(ImGuiIO& io, float size, const std::string& path = std
     iconsConfig.MergeMode = true;
     iconsConfig.PixelSnapH = true;
     iconsConfig.GlyphMinAdvanceX = iconFontSize;
+    iconsConfig.RasterizerDensity = kMenuFontDensity;
     io.Fonts->AddFontFromMemoryCompressedBase85TTF(fontawesome_compressed_data_base85, iconFontSize, &iconsConfig,
                                                    sIconsRanges);
     return font;

--- a/port/port.cpp
+++ b/port/port.cpp
@@ -113,6 +113,10 @@ extern "C" void* sModBridgeAnchorDataFilesRef = (void*)&dFTManagerDataFiles_Ref;
 #include <filesystem>
 #include <system_error>
 
+#ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 #include <dbghelp.h>
@@ -1193,6 +1197,21 @@ int main(int argc, char* argv[]) {
 		}
 		port_log_init(logPath.c_str());
 	}
+
+#ifdef __APPLE__
+	/* Disable the macOS press-and-hold accent/diacritic popup for this app.
+	 * SDL keeps a Cocoa text-input context alive for the game window, so
+	 * holding a movement key (e.g. WASD) makes AppKit pop the accent picker
+	 * instead of delivering key-repeat — the held key stops registering as
+	 * down. AppKit reads ApplePressAndHoldEnabled from the app's user
+	 * defaults when the text-input context is first created, so this must
+	 * run before SDL creates the window (i.e. before PortInit). Writing it
+	 * per-app (kCFPreferencesCurrentApplication) leaves the global/system
+	 * default untouched. Key repeat still works. */
+	CFPreferencesSetAppValue(CFSTR("ApplePressAndHoldEnabled"), kCFBooleanFalse,
+	                         kCFPreferencesCurrentApplication);
+	CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
+#endif
 
 #ifdef _WIN32
 	SetUnhandledExceptionFilter(portWindowsCrashFilter);

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -52,6 +52,18 @@ fi
 APP="$DIST_DIR/$APP_NAME.app"
 JOBS="${JOBS:-$(sysctl -n hw.ncpu 2>/dev/null || echo 4)}"
 
+# Bundle version for Info.plist. Mirrors CMake's BATTLESHIP_VERSION
+# resolution (the string the in-app updater reports) so the Finder
+# Get Info version matches what the app says about itself:
+#   1. $BATTLESHIP_VERSION env — release CI sets this to the tag.
+#   2. Nearest release tag from git.
+#   3. "0.0.0" fallback for tarball builds (no git metadata).
+# CFBundle*Version want dotted numerics, so strip the tag's leading "v"
+# and fall back if what's left isn't numeric.
+APP_TAG="${BATTLESHIP_VERSION:-$(git -C "$ROOT" describe --tags --abbrev=0 2>/dev/null || true)}"
+APP_VERSION="${APP_TAG#v}"
+[[ "$APP_VERSION" =~ ^[0-9]+(\.[0-9]+)*$ ]] || APP_VERSION="0.0.0"
+
 step() { printf '\n\033[36m=== %s ===\033[0m\n' "$1"; }
 fail() { printf '\033[31mERROR: %s\033[0m\n' "$1" >&2; exit 1; }
 truthy() {
@@ -203,8 +215,8 @@ cat > "$APP/Contents/Info.plist" <<EOF
     <key>CFBundleName</key>                <string>$APP_NAME</string>
     <key>CFBundleDisplayName</key>         <string>$APP_NAME</string>
     <key>CFBundleIdentifier</key>          <string>$APP_BUNDLE_ID</string>
-    <key>CFBundleVersion</key>             <string>1.0</string>
-    <key>CFBundleShortVersionString</key>  <string>1.0</string>
+    <key>CFBundleVersion</key>             <string>$APP_VERSION</string>
+    <key>CFBundleShortVersionString</key>  <string>$APP_VERSION</string>
     <key>CFBundlePackageType</key>         <string>APPL</string>
     <key>CFBundleSignature</key>           <string>????</string>
     <key>CFBundleExecutable</key>          <string>$APP_NAME</string>


### PR DESCRIPTION
Three small macOS quality fixes, each in its own commit:

## 1. Retina-crisp ESC menu (`port/gui/Menu.cpp`)
On Retina displays the ImGui SDL2 backend reports `DisplayFramebufferScale = 2`, but the menu fonts (Montserrat + merged FontAwesome icons) were rasterized at 1x and bilinearly upscaled into the 2x framebuffer, leaving the whole ESC menu soft. Set `RasterizerDensity = 2` on all three font configs (macOS only) so the atlas is baked at device density. Layout metrics are unchanged — same on-screen sizes, just sharp; a 1x display simply downsamples the 2x atlas.

## 2. Press-and-hold accent popup (`port/port.cpp`, `CMakeLists.txt`)
Holding a movement key (e.g. WASD) opened the macOS accent/diacritic picker instead of delivering key repeat — SDL keeps a Cocoa text-input context alive for the game window, and AppKit's press-and-hold feature captures held letter keys. Disable the per-app `ApplePressAndHoldEnabled` default at the top of `main()`, before SDL creates the window (AppKit reads it when the text-input context is first created). Written with `kCFPreferencesCurrentApplication`, so the user's global setting is untouched; key repeat still works. CoreFoundation is linked explicitly rather than relying on transitive linkage through libultraship.

## 3. Bundle version was hardcoded 1.0 (`scripts/package-macos.sh`)
`Info.plist` shipped `CFBundleVersion`/`CFBundleShortVersionString` = `1.0` while the project is at v1.5, so Finder's Get Info disagreed with the app. The script now mirrors CMake's `BATTLESHIP_VERSION` resolution (`$BATTLESHIP_VERSION` env from release CI → nearest git tag → fallback), so the plist always matches what the in-app updater reports.

## Testing
Built and playtested on Apple Silicon (macOS 26, M-series), verified US ROM. Menu sharpness eyeballed before/after on a 2x display; press-and-hold verified both behaviorally (held keys keep registering, no accent popup) and via `defaults read` under the packaged app's bundle id; packaged `.app` shows version 1.5 in Finder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)