### PR TITLE
Fix FD from always playing the default track

### DIFF
--- a/port/enhancements/MusicSelection.cpp
+++ b/port/enhancements/MusicSelection.cpp
@@ -24,6 +24,7 @@ extern "C" {
     // Called when the stage select screen is loaded to reset the state
     void port_enhancement_music_select_reset(void) {
         sIsSelectingMusic = false;
+        gManualMusicSelection = -1; // clear the track choice
     }
 
     // Returns:

--- a/port/enhancements/ShuffleMusic.cpp
+++ b/port/enhancements/ShuffleMusic.cpp
@@ -59,10 +59,8 @@ extern "C" {
 
 extern "C" uint32_t port_enhancement_shuffle_music(uint32_t requested_bgm) {
     // 1. highest priority: Manual Selection via Double-Tap UI
-    if (gManualMusicSelection != -1) {
-        uint32_t chosen_track = (uint32_t)gManualMusicSelection;
-        gManualMusicSelection = -1; // Consume the selection so it doesn't loop
-        return chosen_track;
+    if (gManualMusicSelection != -1 && IsStageBGM(requested_bgm)) {
+        return (uint32_t)gManualMusicSelection;
     }
 
     // 2. middle priority: Shuffle Music


### PR DESCRIPTION
When the user previously enabled the music selection screen toggle, and they pick Final Destination as the stage, the default FD music gets played, regardless of what music they choose. This PR fixes that and respects the users' music selection.