### PR TITLE
Fix Sunshine/Apollo virtual DualSense mapping on Linux (triggers read as right stick)

### DIFF
--- a/gamecontrollerdb.txt
+++ b/gamecontrollerdb.txt
@@ -1888,6 +1888,12 @@ xinput,XInput Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,
 03000000120c0000101e000011010000,Zeroplus P4,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b4,leftstick:b10,lefttrigger:a3,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:a4,rightx:a2,righty:a5,start:b9,x:b0,y:b3,platform:Linux,
 03000000120c0000182e000011010000,Zeroplus PS4 Controller,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b4,leftstick:b10,lefttrigger:a3,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:a4,rightx:a2,righty:a5,start:b9,x:b0,y:b3,platform:Linux,
 03000000790000002201000011010000,ZhiXu GuliKit D,a:b0,b:b1,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b4,leftstick:b10,lefttrigger:b6,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:b7,rightx:a2,righty:a3,start:b9,x:b2,y:b3,platform:Linux,
+# Sunshine/Moonlight virtual DualSense (uhid, bustype BLUETOOTH, bcdDevice 0x8111).
+# Sony's real BT DualSense reports version 0x8100 and matches the entry above; the
+# virtual pad's 0x8111 matches nothing, so SDL falls back to its built-in PS5 mapping,
+# which assumes hid-generic descriptor order. Modern kernels bind hid-playstation,
+# which renumbers to ABS_X/Y/Z/RX/RY/RZ -- making a2/a5 (L2/R2) read as the right stick.
+050000004c050000e60c000011810000,Sunshine PS5 (virtual) pad,a:b0,b:b1,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b10,leftshoulder:b4,leftstick:b11,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b12,righttrigger:a5,rightx:a3,righty:a4,start:b9,x:b3,y:b2,platform:Linux,
 
 # Android
 38653964633230666463343334313533,8BitDo Adapter,a:b0,b:b1,back:b15,dpdown:b12,dpleft:b13,dpright:b14,dpup:b11,leftshoulder:b9,leftstick:b7,lefttrigger:b17,leftx:a0,lefty:a1,rightshoulder:b10,rightstick:b8,righttrigger:b18,rightx:a2,righty:a3,start:b6,x:b2,y:b3,platform:Android,


### PR DESCRIPTION
This fixes an issue with trigger axes for Moonlight/Apollo/Sunshine's virtual DualSense controller spoofing a ps5 to have proper input handling, instead of treating L/R trigger axes as right analog stick.

## Symptom

Playing over Moonlight with Sunshine's virtual DualSense on a Linux host, **both triggers drive the right analog stick** and the right stick drives the triggers. Face buttons are wrong too: `a` reads circle, `x` reads cross, and `guide`/`leftstick`/`rightstick` land on R3/PS/L3.

It's not the client-side hardware — it reproduces with every physical controller attached to the streaming client, and `evtest` on the host shows the axes reported correctly.

## Root cause

Sunshine creates its virtual DualSense through **uhid**, so it enumerates as a genuine HID device — bus `0x0005` (Bluetooth), Sony's real DualSense VID/PID `054c:0ce6` — but with **`bcdDevice = 0x8111`**.

A physical Bluetooth DualSense reports `0x8100`, which matches the existing `gamecontrollerdb.txt` entry. `0x8111` matches nothing, so SDL falls back to its **built-in** PS5 mapping — and that fallback assumes `hid-generic` descriptor order.

Modern kernels bind `hid-playstation` instead, which normalizes the axes to `ABS_X/Y/Z/RX/RY/RZ`. The two layouts disagree exactly where it hurts:

| Built-in mapping says | `hid-playstation` actually reports | Result |
|---|---|---|
| `rightx:a2` | `ABS_Z` = **L2** | left trigger → right stick X |
| `righty:a5` | `ABS_RZ` = **R2** | right trigger → right stick Y |
| `lefttrigger:a3` | `ABS_RX` | right stick → left trigger |
| `righttrigger:a4` | `ABS_RY` | right stick → right trigger |

This is **Linux-only** because `osContInit` sets `SDL_HINT_JOYSTICK_HIDAPI=0` there (issue #193 — udev stall plus rumble regressions), so gamepads arrive over evdev. On Windows the HIDAPI PS5 driver parses the HID reports itself and never sees the kernel's axis numbering, so it's unaffected.

## The fix

One `platform:Linux` entry for `054c:0ce6` version `0x8111` matching the `hid-playstation` layout. No code changes.

The CRC field is deliberately zeroed so the entry matches on VID/PID/version regardless of the device name string — Sunshine forks that keep the same uhid emulation are covered even if they rename the pad.

## Verification

Loaded the repo's `gamecontrollerdb.txt` through `SDL_GameControllerAddMappingsFromFile` with `SDL_JOYSTICK_HIDAPI=0` — the same call and hint state `osContInit` uses — and confirmed SDL resolves this entry for the live device instead of its built-in fallback. Gameplay then confirmed by hand over Moonlight: sticks, triggers, and face buttons all correct.

Environment: kernel 7.1.4, SDL 2.32.70, Sunshine virtual DualSense.

## Scope note

Verified against **Sunshine**. Apollo is a Sunshine fork and inherits the same uhid emulation, so it should present identical IDs, but I have not confirmed that on real hardware. Sunshine's virtual DS4 and X360 pads were not tested and may have the same version-mismatch problem.
